### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
     "name" : "OAuth2::Client::Google",
+    "license" : "Artistic-2.0",
     "version" : "0.1.0",
     "description" : "Authenticate against Google's OAuth2 API.",
     "depends" : [ "HTTP::UserAgent", "IO::Socket::SSL", "JSON::Fast" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license